### PR TITLE
Чтение параметров проекции из ini файла

### DIFF
--- a/src/data_source_info.py
+++ b/src/data_source_info.py
@@ -44,6 +44,8 @@ class DataSourceInfo():
         self.tms_url = None
         self.tms_zmin = None
         self.tms_zmax = None
+        self.tms_crs = None
+        self.tms_proj = None
 
         self.wms_url = None
         self.wms_params = None

--- a/src/data_sources_list.py
+++ b/src/data_sources_list.py
@@ -79,6 +79,8 @@ class DataSourcesList():
             ds.tms_url = self.try_read_config(parser, 'tms', 'url', reraise=(ds.type == KNOWN_DRIVERS.TMS))
             ds.tms_zmin = self.try_read_config_int(parser, 'tms', 'zmin')
             ds.tms_zmax = self.try_read_config_int(parser, 'tms', 'zmax')
+            ds.tms_crs = self.try_read_config_int(parser, 'tms', 'crs')
+            ds.tms_proj = self.try_read_config(parser, 'tms', 'proj')
 
             #WMS
             ds.wms_url = self.try_read_config(parser, 'wms', 'url', reraise=(ds.type == KNOWN_DRIVERS.WMS))

--- a/src/py_tiled_layer/tilelayer.py
+++ b/src/py_tiled_layer/tilelayer.py
@@ -72,9 +72,12 @@ class TileLayer(QgsPluginLayer):
         self.setCustomProperty("creditVisibility", self.creditVisibility)
 
         # create a QgsCoordinateReferenceSystem instance if plugin has no instance yet
-        if plugin.crs3857 is None:
-            plugin.crs3857 = QgsCoordinateReferenceSystem(3857)
-        self.setCrs(plugin.crs3857)
+        if layerDef.proj is not None:
+            customcrs = QgsCoordinateReferenceSystem()
+            customcrs.createFromProj4(layerDef.proj)
+        else:
+            customcrs = QgsCoordinateReferenceSystem(layerDef.crs)
+        self.setCrs(customcrs)
         if layerDef.bbox:
             self.setExtent(BoundingBox.degreesToMercatorMeters(layerDef.bbox).toQgsRectangle())
         else:
@@ -263,7 +266,8 @@ class TileLayer(QgsPluginLayer):
                 painter.setRenderHint(QPainter.SmoothPixmapTransform)
 
             # draw tiles
-            if isWebMercator:
+            # if isWebMercator:
+            if False:
                 # no need to reproject tiles
                 self.drawTiles(renderContext, self.tiles)
                 # self.drawTilesDirectly(renderContext, self.tiles)

--- a/src/py_tiled_layer/tiles.py
+++ b/src/py_tiled_layer/tiles.py
@@ -32,6 +32,7 @@ R = 6378137
 class TileDefaultSettings:
     ZMIN = 0
     ZMAX = 18
+    CRS = 3857
 
 
 def degreesToMercatorMeters(lon, lat):
@@ -125,7 +126,7 @@ class TileServiceInfo:
     TSIZE1 = 20037508.342789244
 
     def __init__(self, title, credit, serviceUrl, yOriginTop=1, zmin=TileDefaultSettings.ZMIN,
-                 zmax=TileDefaultSettings.ZMAX, bbox=None):
+                 zmax=TileDefaultSettings.ZMAX, bbox=None, crs=TileDefaultSettings.CRS, proj=None):
         self.title = title
         self.credit = credit
         self.serviceUrl = serviceUrl
@@ -133,6 +134,8 @@ class TileServiceInfo:
         self.zmin = max(zmin, 0)
         self.zmax = zmax
         self.bbox = bbox
+        self.crs = crs
+        self.proj = proj
 
 
     def tileUrl(self, zoom, x, y):

--- a/src/quick_map_services.py
+++ b/src/quick_map_services.py
@@ -85,7 +85,6 @@ class QuickMapServices:
         self._scales_list = None
 
         # TileLayer assets
-        self.crs3857 = None
         self.downloadTimeout = 30  # TODO: settings
         self.navigationMessagesEnabled = Qt.Checked  # TODO: settings
         self.pluginName = 'QuickMapServices'
@@ -219,6 +218,8 @@ class QuickMapServices:
             service_info = TileServiceInfo(self.tr(ds.alias), ds.copyright_text, ds.tms_url)
             service_info.zmin = ds.tms_zmin or service_info.zmin
             service_info.zmax = ds.tms_zmax or service_info.zmax
+            service_info.crs = ds.tms_crs or service_info.crs
+            service_info.proj = ds.tms_proj or service_info.proj
             layer = TileLayer(self, service_info, False)
         if ds.type == KNOWN_DRIVERS.GDAL:
             layer = QgsRasterLayer(ds.gdal_source_file, self.tr(ds.alias))


### PR DESCRIPTION
Добавлено чтение параметров proj и crs из metadata.ini
Убрана "какаято фигня" блокирующая перерисовку на лету для проекции EPSG:3857

PS: Есть один косяк с параметрами Proj4. Если в qgis в списке доступных проекции такие параметры не встречаются, то перепроицирование не идет. Не знаю как добавлять новые проекции в qgis на лету :unamused: .