### PR TITLE
Bump QGIS compatibility to 3.99

### DIFF
--- a/src/metadata.txt
+++ b/src/metadata.txt
@@ -1,7 +1,7 @@
 [general]
 name=QuickMapServices
 qgisMinimumVersion=2.14
-qgisMaximumVersion=3.1
+qgisMaximumVersion=3.99
 description=Collection of easy to add basemaps
 version=0.19.9
 author=NextGIS


### PR DESCRIPTION
Closes #166 

Currently, this plugin is disabled for users of QGIS 3.2. This PR simply bumps the compatibility to support any version from the 3.x series.