### PR TITLE
Fix Deprecation Warnings (QgsCoordinateReferenceSystem constructor is deprecated)

### DIFF
--- a/src/py_tiled_layer/tilelayer.py
+++ b/src/py_tiled_layer/tilelayer.py
@@ -61,7 +61,7 @@ class LayerDefaultSettings(object):
 
 class TileLayer(QgsPluginLayer):
 
-    CRS_3857 = QgsCoordinateReferenceSystem(3857)
+    CRS_3857 = QgsCoordinateReferenceSystem.fromEpsgId(3857)
 
     LAYER_TYPE = "PyTiledLayer"
     MAX_TILE_COUNT = 256

--- a/src/qgis_proj_helper.py
+++ b/src/qgis_proj_helper.py
@@ -5,7 +5,7 @@ from .plugin_settings import PluginSettings
 from .compat2qgis import QGisMessageBarLevel
 
 class ProjectionHelper:
-    CRS_3857 = QgsCoordinateReferenceSystem(3857)
+    CRS_3857 = QgsCoordinateReferenceSystem.fromEpsgId(3857)
 
     @classmethod
     def set_tile_layer_proj(cls, layer, epsg_crs_id, postgis_crs_id, custom_proj):

--- a/src/qms_service_toolbox.py
+++ b/src/qms_service_toolbox.py
@@ -205,7 +205,7 @@ class QmsServiceToolbox(QDockWidget, FORM_CLASS):
             extent = self.iface.mapCanvas().extent()
             map_crs = getCanvasDestinationCrs(self.iface)
             if map_crs.postgisSrid() != 4326:
-                crsDest = QgsCoordinateReferenceSystem(4326)    # WGS 84
+                crsDest = QgsCoordinateReferenceSystem.fromEpsgId(4326)    # WGS 84
                 xform = QgsCoordinateTransform(map_crs, crsDest)
                 extent = xform.transform(extent)
             geom_filter = extent.asWktPolygon()

--- a/src/rb_result_renderer.py
+++ b/src/rb_result_renderer.py
@@ -32,7 +32,7 @@ class RubberBandResultRenderer():
     def __init__(self):
         self.iface = iface
 
-        self.srs_wgs84 = QgsCoordinateReferenceSystem(4326)
+        self.srs_wgs84 = QgsCoordinateReferenceSystem.fromEpsgId(4326)
         self.transform_decorator = QgsCoordinateTransform(self.srs_wgs84, self.srs_wgs84)
 
         self.rb = QgsRubberBand(self.iface.mapCanvas(), QGisGeometryType.Point)


### PR DESCRIPTION
Drop use of deprecated QgsCoordinateReferenceSystem constructor.

See https://github.com/qgis/QGIS/commit/cbc1ee56cc33e1dd26400d2e9834651f26ae09b2 https://github.com/qgis/QGIS/commit/fc06fcef4d18f4d548b1206c4c3084a0071c7e68 https://qgis.org/api/classQgsCoordinateReferenceSystem.html#aab2aeb3e8d3888dd35778701af683a78