### PR TITLE
New WMTS driver

### DIFF
--- a/src/data_source_info.py
+++ b/src/data_source_info.py
@@ -67,6 +67,10 @@ class DataSourceInfo(object):
         self.wms_layers = None
         self.wms_turn_over = None
 
+        self.wmts_url = None
+        self.wmts_params = None
+        self.wmts_layer = None
+
         self.gdal_source_file = None
 
         self.wfs_url = None

--- a/src/data_source_serializer.py
+++ b/src/data_source_serializer.py
@@ -97,6 +97,11 @@ class DataSourceSerializer(object):
 
             ds.wms_turn_over = ConfigReaderHelper.try_read_config_bool(parser, 'wms', 'turn_over')
 
+            #WMTS
+            ds.wmts_url = ConfigReaderHelper.try_read_config(parser, 'wmts', 'url', reraise=(ds.type == KNOWN_DRIVERS.WMTS), default="")
+            ds.wmts_params = ConfigReaderHelper.try_read_config(parser, 'wmts', 'params', default="")
+            ds.wmts_layer = ConfigReaderHelper.try_read_config(parser, 'wmts', 'layer', default="")
+
             #GDAL
             if ds.type == KNOWN_DRIVERS.GDAL:
                 gdal_conf = ConfigReaderHelper.try_read_config(parser, 'gdal', 'source_file', reraise=(ds.type == KNOWN_DRIVERS.GDAL))
@@ -180,6 +185,12 @@ class DataSourceSerializer(object):
             if epsg is not None:
                 ds.wms_params += '&crs=EPSG:' + str(epsg)
 
+        #WMTS
+        if ds.type.lower() == KNOWN_DRIVERS.WMTS.lower():
+            ds.wmts_url = json_data['url']
+            ds.wmts_layer = json_data['layer']
+            ds.wmts_params = json_data['params']
+
         #WFS
         if ds.type.lower() == KNOWN_DRIVERS.WFS.lower():
             ds.wfs_url = json_data['url']
@@ -246,6 +257,11 @@ class DataSourceSerializer(object):
             config.set('wms', 'params', ds_info.wms_params)
             config.set('wms', 'layers', ds_info.wms_layers)
             config.set('wms', 'turn_over', ds_info.wms_turn_over)
+
+        if ds_info.type == KNOWN_DRIVERS.WMTS:
+            config.set('wmts', 'url', ds_info.wmts_url)
+            config.set('wmts', 'params', ds_info.wmts_params)
+            config.set('wmts', 'layer', ds_info.wmts_layer)
 
         if ds_info.type == KNOWN_DRIVERS.GDAL:
             config.set('gdal', 'source_file', os.path.basename(ds_info.gdal_source_file))

--- a/src/ds_edit_dialog.py
+++ b/src/ds_edit_dialog.py
@@ -17,6 +17,7 @@ from .supported_drivers import KNOWN_DRIVERS
 from .gui.editor_widget_gdal import EditorWidgetGdal
 from .gui.editor_widget_tms import EditorWidgetTms
 from .gui.editor_widget_wms import EditorWidgetWms
+from .gui.editor_widget_wmts import EditorWidgetWmts
 from .gui.editor_widget_wfs import EditorWidgetWfs
 from .gui.editor_widget_geojson import EditorWidgetGeoJson
 from .gui.line_edit_color_validator import LineEditColorValidator
@@ -43,6 +44,7 @@ class DsEditDialog(QDialog, FORM_CLASS):
             KNOWN_DRIVERS.GDAL: EditorWidgetGdal(),
             KNOWN_DRIVERS.TMS: EditorWidgetTms(),
             KNOWN_DRIVERS.WMS: EditorWidgetWms(),
+            KNOWN_DRIVERS.WMTS: EditorWidgetWmts(),
             KNOWN_DRIVERS.WFS: EditorWidgetWfs(),
             KNOWN_DRIVERS.GEOJSON: EditorWidgetGeoJson(),
         }

--- a/src/gui/editor_widget_wmts.py
+++ b/src/gui/editor_widget_wmts.py
@@ -1,0 +1,40 @@
+import os
+
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QWidget, QMessageBox
+
+from .line_edit_color_validator import LineEditColorValidator
+
+FORM_CLASS, _ = uic.loadUiType(os.path.join(
+    os.path.dirname(__file__), 'editor_widget_wmts.ui'))
+
+
+class EditorWidgetWmts(QWidget, FORM_CLASS):
+
+    def __init__(self, parent=None):
+        super(EditorWidgetWmts, self).__init__(parent)
+        self.setupUi(self)
+        self.wmts_validator = LineEditColorValidator(self.txtUrl, 'http[s]?://.+', error_tooltip='http{s}://any_text')
+
+
+    def feel_form(self, ds_info):
+        self.ds_info = ds_info
+        self.txtUrl.setText(ds_info.wmts_url)
+        self.txtParams.setText(ds_info.wmts_params)
+        self.txtLayer.setText(ds_info.wmts_layer)
+
+    def feel_ds_info(self, ds_info):
+        ds_info.wmts_url = self.txtUrl.text()
+        ds_info.wmts_params = self.txtParams.text()
+        ds_info.wmts_layer = self.txtLayer.text()
+
+    def validate(self, ds_info):
+        if not ds_info.wmts_url:
+            QMessageBox.critical(self, self.tr('Error on save data source'), self.tr('Please, enter WMTS url'))
+            return False
+
+        if not self.wmts_validator.is_valid():
+            QMessageBox.critical(self, self.tr('Error on save data source'), self.tr('Please, enter correct value for WMTS url'))
+            return False
+
+        return True

--- a/src/gui/editor_widget_wmts.ui
+++ b/src/gui/editor_widget_wmts.ui
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>395</width>
+    <height>169</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::ExpandingFieldsGrow</enum>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="uRLLabel">
+     <property name="text">
+      <string>URL</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="txtUrl"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="paramsLabel">
+     <property name="text">
+      <string>Params</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="txtParams"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="layerLabel">
+     <property name="text">
+      <string>Layer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="txtLayer"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/i18n/base.ts
+++ b/src/i18n/base.ts
@@ -384,6 +384,24 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>EditorWidgetWmts</name>
+    <message>
+        <location filename="../gui/editor_widget_wmts.py" line="37"/>
+        <source>Error on save data source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gui/editor_widget_wmts.py" line="33"/>
+        <source>Please, enter WMTS url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gui/editor_widget_wmts.py" line="37"/>
+        <source>Please, enter correct value for WMTS url</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FileSelectionWidget</name>
     <message>
         <location filename="../file_selection_widget.py" line="51"/>
@@ -405,6 +423,16 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/editor_widget_wms.ui" line="23"/>
+        <source>URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gui/editor_widget_wmts.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gui/editor_widget_wmts.ui" line="23"/>
         <source>URL</source>
         <translation type="unfinished"></translation>
     </message>
@@ -461,6 +489,16 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../gui/editor_widget_wms.ui" line="53"/>
         <source>Turn over</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gui/editor_widget_wmts.ui" line="33"/>
+        <source>Params</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../gui/editor_widget_wmts.ui" line="43"/>
+        <source>Layer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/qgis_map_helpers.py
+++ b/src/qgis_map_helpers.py
@@ -129,6 +129,16 @@ def add_layer_to_map(ds):
             tr(ds.alias),
             "ogr")
         layers4add.append(layer)
+        
+    if ds.type.lower() == KNOWN_DRIVERS.WMTS.lower():
+        qgis_wmts_uri = 'url=' + ds.wmts_url
+        if ds.wmts_layer:
+            qgis_wmts_uri += '&layers=' + ds.wmts_layer
+        if ds.wmts_params:
+            qgis_wmts_uri += '&' + ds.wmts_params
+            
+        layer = QgsRasterLayer(qgis_wmts_uri, tr(ds.alias), KNOWN_DRIVERS.WMS.lower())
+        layers4add.append(layer)
 
     for layer in layers4add:
         if not layer.isValid():

--- a/src/supported_drivers.py
+++ b/src/supported_drivers.py
@@ -24,6 +24,7 @@
 
 class KNOWN_DRIVERS(object):
     WMS = 'WMS'
+    WMTS = 'WMTS'
     TMS = 'TMS'
     GDAL = 'GDAL'
     WFS = 'WFS'
@@ -31,6 +32,7 @@ class KNOWN_DRIVERS(object):
 
     ALL_DRIVERS = [
         WMS,
+        WMTS,
         TMS,
         GDAL,
         WFS,


### PR DESCRIPTION
This PR provides a new Driver for WMTS Layers. You can define the full URL of the Service using three parameters:
- URL base of the service.
- Parameters: CRS, TileMatrixSet....
- Layer name.

The entry in the serialized DataSource settings file can be similar to:

```
...
[wmts]
url = https://myservice.es/ogc/wmts/1.0.0/WMTSCapabilities.xml
params = tileMatrixSet=epsg4326&crs=EPSG:4326&styles=default&format=image/png
layer = mapabase

```