### PR TITLE
Clarify 3857 as EPSG code to avoid deprecation.

### DIFF
--- a/src/qgis_proj_helper.py
+++ b/src/qgis_proj_helper.py
@@ -5,7 +5,7 @@ from .plugin_settings import PluginSettings
 from .compat2qgis import QGisMessageBarLevel
 
 class ProjectionHelper:
-    CRS_3857 = QgsCoordinateReferenceSystem(3857)
+    CRS_3857 = QgsCoordinateReferenceSystem("EPSG:3857")
 
     @classmethod
     def set_tile_layer_proj(cls, layer, epsg_crs_id, postgis_crs_id, custom_proj):


### PR DESCRIPTION
Avoid deprecation warning from https://qgis.org/pyqgis/master/core/QgsCoordinateReferenceSystem.html