### PR TITLE
Fix syntax warning

### DIFF
--- a/src/py_tiled_layer/tiles.py
+++ b/src/py_tiled_layer/tiles.py
@@ -181,9 +181,9 @@ class TileServiceInfo(object):
                 bit = zoom - i
                 digit = ord('0')
                 mask = 1 << (bit - 1)  # if (bit - 1) > 0 else 1 >> (bit - 1)
-                if (x & mask) is not 0:
+                if (x & mask) != 0:
                     digit += 1
-                if (y & mask) is not 0:
+                if (y & mask) != 0:
                     digit += 2
                 quadkey += chr(digit)
             return self.serviceUrl.replace("{q}", str(quadkey))


### PR DESCRIPTION
Using QGIS 3.22.9-Białowieża (LTR) with Python 3.9.5, I am seeing the following warnings in the QGIS Log Messages window (Python warning tab):

```
2022-08-04T23:25:05     WARNING    warning:C:\Users/admin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\quick_map_services\py_tiled_layer\tiles.py:184: SyntaxWarning: "is not" with a literal. Did you mean "!="?
              if (x & mask) is not 0:
             ...
```

I assume that this can be changed safely?